### PR TITLE
Took out redundant second sel() loop

### DIFF
--- a/JavaSetterGetter.py
+++ b/JavaSetterGetter.py
@@ -23,7 +23,7 @@ class JavaSetterGetterCommand(sublime_plugin.TextCommand):
     def run(self, edit):
 
         selections = getSelections(self.view)
-        selected_text = selections["position"]
+        selected_text = selections["selections"]
         properties = []
         insert_position = selections["position"]
         output_arr = []

--- a/JavaSetterGetter.py
+++ b/JavaSetterGetter.py
@@ -17,15 +17,15 @@ def getSelections(view):
             else:
                 selected.append(line)
 
-    return [position, selected]
+    return {"position": position, "selections": selected}
 
 class JavaSetterGetterCommand(sublime_plugin.TextCommand):
     def run(self, edit):
 
         selections = getSelections(self.view)
-        selected_text = selections[1]
+        selected_text = selections["position"]
         properties = []
-        insert_position = selections[0]
+        insert_position = selections["position"]
         output_arr = []
 
 

--- a/JavaSetterGetter.py
+++ b/JavaSetterGetter.py
@@ -8,7 +8,13 @@ def getLastSelection(view):
         if sel.end() > position:
             position = sel.end()
             if '\n' in view.substr(sel):
-                selected.extend(view.substr(sel).split('\n'))  
+                # I appended my plugin for this, like the idea but found that
+                # if \n is found at the beginning, it doesn't generate the methods
+                #selected.extend(view.substr(sel).split('\n'))  
+                
+                line = view.substr(sel).split("\n")
+                for ln in line:
+                    selected.append(ln)
             else:
                 selected.append(view.substr(sel))
 
@@ -18,7 +24,6 @@ class JavaSetterGetterCommand(sublime_plugin.TextCommand):
     def run(self, edit):
 
         selections = getLastSelection(self.view)
-        sels = self.view.sel()
         selected_text = selections[1]
         properties = []
         insert_position = selections[0]
@@ -53,11 +58,17 @@ class JavaSetterGetterCommand(sublime_plugin.TextCommand):
         try:
             edit = self.view.begin_edit('java_setter_getter')
             insert_count = self.view.insert(edit, insert_position, '\n'.join(output_arr))
-            final = getLastSelection(self.view)
-            if insert_position == final[0]:
-                final[0] = final[0] + insert_count
+            #final = getLastSelection(self.view)
+            #if insert_position == final[0]:
+            #    final[0] = final[0] + insert_count
+
+            # insert_count + insert_position = final[0] always. I had failed to see
+            # that self.view.insert returned an int (I'm learning the API myself)
+            # We can eliminate the second call of getLastSelection(self.view)
+            # and just run the following:
 
             self.view.sel().clear()
-            self.view.sel().add(sublime.Region(insert_position, final[0]))
+            #self.view.sel().add(sublime.Region(insert_position, final[0]))
+            self.view.sel().add(sublime.Region(insert_position, (insert_position + insert_count)))
         finally:
             self.view.end_edit(edit)

--- a/JavaSetterGetter.py
+++ b/JavaSetterGetter.py
@@ -1,29 +1,28 @@
 import sublime, sublime_plugin
 
-def getLastSelection(view):
+def getSelections(view):
     position = 0
     selected = []
     sels     = view.sel()
     for sel in sels:
         if sel.end() > position:
             position = sel.end()
-            if '\n' in view.substr(sel):
-                # I appended my plugin for this, like the idea but found that
-                # if \n is found at the beginning, it doesn't generate the methods
-                #selected.extend(view.substr(sel).split('\n'))  
-                
-                line = view.substr(sel).split("\n")
-                for ln in line:
-                    selected.append(ln)
+            line     = view.substr(sel)
+            # Check for CRLF
+            if "\r\n" in line:
+                selected.extend(line.split("\r\n"))
+            # Check for LF
+            elif: "\n" in line:
+                selected.extend(line.split("\n"))
             else:
-                selected.append(view.substr(sel))
+                selected.append(line)
 
     return [position, selected]
 
 class JavaSetterGetterCommand(sublime_plugin.TextCommand):
     def run(self, edit):
 
-        selections = getLastSelection(self.view)
+        selections = getSelections(self.view)
         selected_text = selections[1]
         properties = []
         insert_position = selections[0]


### PR DESCRIPTION
The second call of getLastSelection() is redundant as (insert_count + insert_position) equals the same and we don't need to process the selections a second time.

Also added a line loop if \n is found in a selection.
