### PR TITLE
Use regex to match field lines and a few other minor changes

### DIFF
--- a/JavaSetterGetter.py
+++ b/JavaSetterGetter.py
@@ -1,62 +1,84 @@
 import sublime, sublime_plugin
+import re
+
+DEBUG = False
+
+java_field_pat = "(?P<indent>\s*)" + \
+                 "(?P<access>protected|private)" + \
+                 "(?: (?P<transient>transient|volatile))?" + \
+                 "(?: (?P<static>static))?" + \
+                 "(?: (?P<final>final))?" + \
+                 "(?: (?P<type>[a-zA-Z0-9_$]+))" + \
+                 "(?: (?P<varname>[a-zA-Z0-9_$]+))" + \
+                 "(?:\s*=.+)?;"
+
+java_field_pat = re.compile(java_field_pat)
+
+def matchdict(text):
+    m = java_field_pat.match(text)
+    if m:
+        return m.groupdict()
+    else:
+        return {}
 
 def getSelections(view):
     position = 0
     selected = []
     sels     = view.sel()
-    for sel in sels:
-        if sel.end() > position:
-            position = sel.end()
-            line     = view.substr(sel)
-            # Check for CRLF
-            if "\r\n" in line:
-                selected.extend(line.split("\r\n"))
-            # Check for LF
-            elif "\n" in line:
-                selected.extend(line.split("\n"))
-            else:
-                selected.append(line)
 
-    return {"position": position, "selections": selected}
+    for sel in sels:
+        lineRegions = view.lines(sel)
+        for lineRegion in lineRegions:
+            position = max(position, lineRegion.end())
+            selected.extend(view.substr(lineRegion).split("\n"))
+
+    selection_matches = []
+    for line in selected:
+        md = matchdict(line)
+        if DEBUG:
+            print line, md
+        if md.get("access", None) is not None: # Make sure it's private or protected
+            if md.get("static", None) is None: # Make sure it's not static
+                if md.get("final", None) is None: # Make sure it's not final
+                    selection_matches.append(md)
+    return {"position": position, "selections": selection_matches}
 
 class JavaSetterGetterCommand(sublime_plugin.TextCommand):
     def run(self, edit):
 
         selections = getSelections(self.view)
-        selected_text = selections["selections"]
+        selection_matches = selections["selections"]
         properties = []
         insert_position = selections["position"]
-        output_arr = []
 
-        for line in selected_text:
-            line = line.strip();
-            if len(line) > 0 and line[0] != '@':
-                plain_line = line.split()
-                if len(plain_line) != 3:
-                    sublime.error_message("You probably have some syntax issues. Check your code.")
-                    return
+        getter_arr = []
+        setter_arr = []
 
-                properties.append( [plain_line[1], plain_line[2] ] )
+        getterTemplate = """
+{3}public {1} get{0}() {{
+{3}    return this.{2};
+{3}}}"""
 
-        for prop in properties:
-            property_name = prop[1].replace(';', '')
+        setterTemplate = """
+{3}public void set{0}({1} {2}) {{
+{3}    this.{2} = {2};
+{3}}}"""
+
+        for prop in selection_matches:
+            property_name = prop['varname']
             capitalized_name = property_name[0].capitalize() + property_name[1:len(property_name)]
 
-            template = """
-    public void set{0}({1} {2}) {{
-        this.{2} = {2};
-    }}
-
-    public {1} get{0}() {{
-        return this.{2};
-    }}"""
-
-            output_arr.append(template.format(capitalized_name, prop[0], property_name))
+            getter_arr.append(getterTemplate.format(capitalized_name, prop['type'], prop['varname'], prop['indent']))
+            setter_arr.append(setterTemplate.format(capitalized_name, prop['type'], prop['varname'], prop['indent']))
 
         try:
             edit = self.view.begin_edit('java_setter_getter')
-            insert_count = self.view.insert(edit, insert_position, '\n'.join(output_arr))
+            properties_text = "\n" + "\n".join(getter_arr) + "\n" + "\n".join(setter_arr)
+            insert_count = self.view.insert(edit, insert_position, properties_text)
             self.view.sel().clear()
             self.view.sel().add(sublime.Region(insert_position, (insert_position + insert_count)))
+        except Exception, ex:
+            if DEBUG:
+                print ex
         finally:
             self.view.end_edit(edit)

--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,0 +1,1 @@
+{"url": "https://github.com/enriquein/JavaSetterGetter", "version": "1.2.0", "description": "Creates setters and getters for your class private properties like other IDEs do."}


### PR DESCRIPTION
The script now uses a regex pattern to match the lines, filtering out
any public, static, and/or final fields, as we don't want to turn these
into properties.  Also handles default values on the fields (i.e. the
field being declared with an assignment as well).  Also changes the
format of the template slightly, and groups the getters separately from
the setters.
