### PR TITLE
Updated packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -11,7 +11,7 @@
                 "*": [
                     {
                         "version": "1.6.0",
-                        "url": "https://github.com/enriquein/JavaSetterGetter/archive/v1.6.0.zip"
+                        "url": "https://nodeload.github.com/enriquein/JavaSetterGetter/zip/master"
                     }
                 ]
             }


### PR DESCRIPTION
There was an issue with Package Control trying to download `https://github.com/enriquein/JavaSetterGetter/archive/v1.6.0.zip` After looking at a few other packages and how they list the zip file in the `packages.json` I changed it to `https://nodeload.github.com/enriquein/JavaSetterGetter/zip/master`

Inside `Package Control.py` - The script that was throwing the errors, I tested it with:

``` python
# lines 3182 - 3185 in Package Control.py
if url == 'https://github.com/enriquein/JavaSetterGetter/archive/v1.6.0.zip':
    url = 'https://nodeload.github.com/enriquein/JavaSetterGetter/zip/master'

package_bytes = self.download_url(url, 'Error downloading package.')
```

And the package installed just fine.
